### PR TITLE
[main][fix] Rename Strategy Interfaces

### DIFF
--- a/src/lockdrop/SimpleStrategy.sol
+++ b/src/lockdrop/SimpleStrategy.sol
@@ -13,18 +13,18 @@ contract SimpleStrategy {
     pool = pool_;
   }
 
-  function simpleStrategyExecute(uint256 _tokenAmount, address _tokenAddress)
+  function execute(uint256 tokenAmount, address tokenAddress)
     external
     returns (uint256)
   {
     // 1. Retrive Base Token
-    IERC20(_tokenAddress).safeTransferFrom(
+    IERC20(tokenAddress).safeTransferFrom(
       msg.sender,
       address(this),
-      _tokenAmount
+      tokenAmount
     );
 
     // 2. Deposit to PLP Token to get amount of PLP
-    return pool.addLiquidity(_tokenAddress, _tokenAmount, msg.sender, 0);
+    return pool.addLiquidity(tokenAddress, tokenAmount, msg.sender, 0);
   }
 }

--- a/src/lockdrop/interfaces/ILockdropStrategy.sol
+++ b/src/lockdrop/interfaces/ILockdropStrategy.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.14;
 
 interface ILockdropStrategy {
-  function simpleStrategyExecute(uint256 _tokenAmount, address _tokenAddress)
+  function execute(uint256 tokenAmount, address tokenAddress)
     external
     returns (uint256);
 }


### PR DESCRIPTION
## Description
Rename the strategy interface for global use in lockdrop contract

## ChangeLogs:
1 ISimpleStrategy -> ILockdropStrategy
2 rename Simple Strategy execute function
